### PR TITLE
nullable checks

### DIFF
--- a/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
+++ b/Libraries/src/Amazon.Lambda.AspNetCoreServer/APIGatewayProxyFunction.cs
@@ -141,7 +141,7 @@ namespace Amazon.Lambda.AspNetCoreServer
                 requestFeatures.Scheme = "https";
                 requestFeatures.Method = apiGatewayRequest.HttpMethod;
 
-                if (string.IsNullOrWhiteSpace(apiGatewayRequest.RequestContext?.DomainName))
+                if (string.IsNullOrWhiteSpace(apiGatewayRequest?.RequestContext?.DomainName))
                 {
                     _logger.LogWarning($"Request does not contain domain name information but is derived from {nameof(APIGatewayProxyFunction)}.");
                 }
@@ -199,8 +199,8 @@ namespace Amazon.Lambda.AspNetCoreServer
 
                 if (!requestFeatures.Headers.ContainsKey("Host"))
                 {
-                    var apiId = apiGatewayRequest.RequestContext?.ApiId ?? "";
-                    var stage = apiGatewayRequest.RequestContext?.Stage ?? "";
+                    var apiId = apiGatewayRequest?.RequestContext?.ApiId ?? "";
+                    var stage = apiGatewayRequest?.RequestContext?.Stage ?? "";
 
                     requestFeatures.Headers["Host"] = $"apigateway-{apiId}-{stage}";
                 }


### PR DESCRIPTION
apiGatewayRequest.RequestContext could possibly be null

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
